### PR TITLE
Add centos/post.pp changes for module_filename changes

### DIFF
--- a/manifests/passenger/apache/centos/post.pp
+++ b/manifests/passenger/apache/centos/post.pp
@@ -13,8 +13,9 @@ class rvm::passenger::apache::centos::post(
 ) {
   exec {
     'passenger-install-apache2-module':
+      environment => ["rvm_prefix=${rvm_prefix}", "rvm_path=${rvm_prefix}/rvm", "rvm_bin_path=${binpath}", "HOME=/tmp"],
       command   => "${rvm::passenger::apache::binpath}rvm ${rvm::passenger::apache::ruby_version} exec passenger-install-apache2-module -a",
-      creates   => "${rvm::passenger::apache::gempath}/passenger-${rvm::passenger::apache::version}/ext/apache2/mod_passenger.so",
+      creates   => "${gempath}/passenger-${version}/${compiled_module_fn}",
       logoutput => 'on_failure',
       require   => [Rvm_gem['passenger'], Package['httpd','httpd-devel','mod_ssl']];
   }
@@ -24,5 +25,10 @@ class rvm::passenger::apache::centos::post(
       ensure  => file,
       content => template('rvm/passenger-apache.load.erb', 'rvm/passenger-apache.conf.erb'),
       require => Exec['passenger-install-apache2-module'];
+  }
+
+  # Add Apache restart hooks
+  if defined(Service['httpd']) {
+    File['/etc/httpd/conf.d/passenger.conf'] ~> Service['httpd']
   }
 }


### PR DESCRIPTION
The Centos post.pp didn't have your changes added for the module filename changes and addition of HOME environment required by the Passenger compile.  I also added the service hook to force a reload of Apache after the Passenger build and config file update.

I used yours since blt04 hasn't merged your pull-request yet.
