### PR TITLE
upgrade from non-gpg rvm to signed version

### DIFF
--- a/manifests/system.pp
+++ b/manifests/system.pp
@@ -36,6 +36,7 @@ class rvm::system($version=undef) {
       exec { 'system-rvm-get':
         path    => '/usr/local/rvm/bin:/usr/bin:/usr/sbin:/bin',
         command => "rvm get ${version}",
+        require => Exec['system-rvm-gpg-key'],
         before  => Exec['system-rvm'], # so it doesn't run after being installed the first time
       }
     }


### PR DESCRIPTION
Given a rvm version was installed before gpg signing was introduced
When we request a new version through puppet
Then the gpg key should be imported before fetching the new version.