### PR TITLE
Add option to turn off Passenger version number in header

### DIFF
--- a/manifests/passenger/apache.pp
+++ b/manifests/passenger/apache.pp
@@ -6,7 +6,8 @@ class rvm::passenger::apache(
   $maxpoolsize = '6',
   $poolidletime = '300',
   $maxinstancesperapp = '0',
-  $spawnmethod = 'smart-lv2'
+  $spawnmethod = 'smart-lv2',
+  $disable_version_in_header = false,
 ) {
 
   case $::operatingsystem {

--- a/templates/passenger-apache.conf.erb
+++ b/templates/passenger-apache.conf.erb
@@ -15,4 +15,7 @@
 <% if @version >= "4.0.42" %>
   PassengerFriendlyErrorPages off
 <% end %>
+<% if @version >= "5.0.0" && @disable_version_in_header %>
+  PassengerShowVersionInHeader off
+<% end %>
 </IfModule>


### PR DESCRIPTION
Added an option to turn off the Passenger version in the HTTP header for security reasons. Default is to show the version (hide the `PassengerShowVersionInHeader` config).

Does not work currently in Apache. PR on Passenger repository pending to fix this issue.
